### PR TITLE
Larachat on Slack doesn't have nova channel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 To report a Nova bug, open an issue on this repository. Please include your Nova version number and a full description of your problem. If applicable, please provide screenshots.
 
-This issue board is for tracking bugs, not general development questions. Please direct general questions to [#nova on Laravel's Discord](https://discordapp.com/invite/mPZNm7A) or [#nova on the Larachat Slack Channel](https://larachat.co/).
+This issue board is for tracking bugs, not general development questions. Please direct general questions to [#nova on Laravel's Discord](https://discordapp.com/invite/mPZNm7A).


### PR DESCRIPTION
![Screenshot 2020-10-08 at 11 20 42 AM](https://user-images.githubusercontent.com/172966/95411254-a5e5b980-0958-11eb-811d-387b02ce10f7.png)
